### PR TITLE
On mouse click, move caret to the closest spot

### DIFF
--- a/src/main/java/com/xdavide9/jnotepad/gui/Find.java
+++ b/src/main/java/com/xdavide9/jnotepad/gui/Find.java
@@ -93,7 +93,7 @@ public class Find {
                         BorderFactory.createEmptyBorder(1, 6, 2, 4)));
             }
         });
-        //disable the 'Find Next' button if the text field is empty
+        // disable the 'Find Next' button if the text field is empty
         searchTextField.getDocument().addDocumentListener(new DocumentListener() {
 
             @Override
@@ -110,7 +110,7 @@ public class Find {
             }
         });
 
-        //click the 'Find Next' button when enter key is pressed in the JTextField
+        // click the 'Find Next' button when enter key is pressed in the JTextField
         searchTextField.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
@@ -179,21 +179,21 @@ public class Find {
             String notepadText = matchCase.isSelected() ? textArea.getText() : textArea.getText().toLowerCase(Locale.ROOT);
             String findText = matchCase.isSelected() ? searchTextField.getText() : searchTextField.getText().toLowerCase(Locale.ROOT);
 
-            //the index inside notepadText where the next occurrence of findText is found; will be -1 if not found
+            // the index inside notepadText where the next occurrence of findText is found; will be -1 if not found
             int nextIndex;
 
             if(wrap.isSelected()) {
                 if(upRadioButton.isSelected()) {
                     String aboveText = notepadText.substring(0, caretPositionMark);
                     nextIndex = aboveText.contains(findText) ? aboveText.lastIndexOf(findText) : notepadText.lastIndexOf(findText);
-                } else { //down radio button is selected
+                } else { // down radio button is selected
                     String belowText = notepadText.substring(caretPositionDot);
                     nextIndex = belowText.contains(findText) ? belowText.indexOf(findText) + caretPositionDot : notepadText.indexOf(findText);
                 }
-            } else { //wrap isn't selected
+            } else { // wrap isn't selected
                 if(upRadioButton.isSelected()) {
                     nextIndex = notepadText.substring(0, caretPositionMark).lastIndexOf(findText);
-                } else { //down radio button is selected
+                } else { // down radio button is selected
                     String belowText = notepadText.substring(caretPositionDot);
                     nextIndex = belowText.contains(findText) ? belowText.indexOf(findText) + caretPositionDot : -1;
                 }

--- a/src/main/java/com/xdavide9/jnotepad/gui/Gui.java
+++ b/src/main/java/com/xdavide9/jnotepad/gui/Gui.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.swing.*;
+import javax.swing.text.BadLocationException;
 import java.awt.*;
 import java.awt.event.*;
 import java.util.Objects;
@@ -59,6 +60,7 @@ public class Gui implements ActionListener {
         textArea.setLineWrap(lineWrap);
         textArea.setWrapStyleWord(true);
         textArea.getDocument().addUndoableEditListener(e -> editService.getUndoManager().addEdit(e.getEdit()));
+        textArea.addMouseListener(new ClosestCaret());
 
         scrollPane = new JScrollPane(textArea);
         scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
@@ -103,6 +105,34 @@ public class Gui implements ActionListener {
             case "Line Wrap" -> formatService.lineWrap();
             // help
             case "Contact" -> helpService.contact();
+        }
+    }
+
+    /**
+     * On mouse press, horizontally move the caret position as close to the mouse as possible, like in Notepad -
+     * Default JTextArea behavior is for the caret to always position to the left of the mouse
+     */
+    private class ClosestCaret extends MouseAdapter {
+        @Override
+        public void mousePressed(MouseEvent e) {
+            // verify that there isn't selected text, and that the caret isn't at the end of the document
+            if(textArea.getSelectedText() != null || textArea.getCaretPosition() == textArea.getText().length())
+                return;
+
+            try {
+                // as per default behavior, the caret will start to the left of the mouse
+                Rectangle pixelPositionLeftCaret = textArea.modelToView2D( textArea.getCaretPosition() ).getBounds();
+                textArea.setCaretPosition(textArea.getCaretPosition() + 1);
+                Rectangle pixelPositionRightCaret = textArea.modelToView2D( textArea.getCaretPosition() ).getBounds();
+
+                // if the caret position to the left is closer, or is on the line above, move caret back to the left
+                if(Math.abs(e.getX() - pixelPositionLeftCaret.x) <= Math.abs(e.getX() - pixelPositionRightCaret.x) ||
+                        pixelPositionLeftCaret.y != pixelPositionRightCaret.y) {
+                    textArea.setCaretPosition(textArea.getCaretPosition() - 1);
+                }
+            } catch (BadLocationException ex) {
+                log.error("Could not set caret position", ex);
+            }
         }
     }
 

--- a/src/main/java/com/xdavide9/jnotepad/services/MenuBarService.java
+++ b/src/main/java/com/xdavide9/jnotepad/services/MenuBarService.java
@@ -1,5 +1,7 @@
 package com.xdavide9.jnotepad.services;
 
+import com.xdavide9.jnotepad.JNotepad;
+import com.xdavide9.jnotepad.util.OperatingSystem;
 import lombok.Getter;
 
 import javax.swing.*;
@@ -18,7 +20,7 @@ public class MenuBarService {
     int shortcutKey;
 
     public MenuBarService(ActionListener listener) {
-        shortcutKey = KeyEvent.CTRL_DOWN_MASK;
+        shortcutKey = JNotepad.os == OperatingSystem.MAC ? KeyEvent.META_DOWN_MASK : KeyEvent.CTRL_DOWN_MASK;
         menuBar = new JMenuBar();
 
         createMenus();


### PR DESCRIPTION
Default JTextArea behavior is for the caret to always move to the left
of the mouse.  This change emulates Notepad's behavior.

Fix shortcuts on Mac by using the Command key instead of CTRL.