### PR TITLE
Fix title bar's color on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > Inspired by Windows 10 Notepad, but dark-themed
 
 ### Installation
-- For Windows, you can install [JNotepad.exe](https://github.com/woodrow73/JNotepad/releases) as a standalone application
+- For a standalone application, there's [JNotepad.exe](https://github.com/woodrow73/JNotepad/releases) for Windows, or [JNotepad.dmg](https://github.com/woodrow73/JNotepad/releases) for Mac
 - To run the [_Jar_](https://github.com/woodrow73/JNotepad/releases), make sure you have [_Java 17_](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) or later installed
 - You can run the application with `java -jar JNotepadFork-<<version>>.jar`
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.xdavide9</groupId>
     <artifactId>JNotepad</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/com/xdavide9/jnotepad/JNotepad.java
+++ b/src/main/java/com/xdavide9/jnotepad/JNotepad.java
@@ -49,6 +49,9 @@ public class JNotepad {
     }
 
     private static void customizeLaf() {
+        if(os == OperatingSystem.MAC)
+            System.setProperty("apple.awt.application.appearance", "system"); // allows the title bar to be dark on Mac
+
         try {
             UIManager.setLookAndFeel(new FlatDarculaLaf() {
                 //removing the content of this method because it was responsible for producing an annoying beep sound

--- a/src/main/java/com/xdavide9/jnotepad/gui/Find.java
+++ b/src/main/java/com/xdavide9/jnotepad/gui/Find.java
@@ -1,6 +1,7 @@
 package com.xdavide9.jnotepad.gui;
 
 import com.xdavide9.jnotepad.JNotepad;
+import com.xdavide9.jnotepad.services.MenuBarService;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -48,6 +49,7 @@ public class Find {
         frame.setIconImage(icon);
         frame.setResizable(false);
         frame.setBounds(100, 100, 392, 181);
+
         JPanel contentPane = new JPanel();
         contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
         frame.setContentPane(contentPane);
@@ -93,6 +95,19 @@ public class Find {
                         BorderFactory.createEmptyBorder(1, 6, 2, 4)));
             }
         });
+
+        // when CTRL+F is pressed while the Find window is in focus, select the text in searchTextField & request focus
+        JRootPane rootPane = frame.getRootPane();
+        rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
+                KeyStroke.getKeyStroke(KeyEvent.VK_F, MenuBarService.shortcutKey), "Find In Focus");
+        rootPane.getActionMap().put("Find In Focus", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                searchTextField.select(0, searchTextField.getText().length());
+                SwingUtilities.invokeLater(() -> searchTextField.requestFocus());
+            }
+        });
+
         // disable the 'Find Next' button if the text field is empty
         searchTextField.getDocument().addDocumentListener(new DocumentListener() {
 
@@ -156,13 +171,14 @@ public class Find {
         contentPane.add(wrap);
     }
 
-    /** When Control+F is pressed, display the Find Frame */
+    /** When Control+F is pressed, display the Find Frame and select all text inside searchTextField */
     public void openFindWindow() {
         if(!frame.isVisible()) {
             frame.setLocationRelativeTo(gui.getFrame());
             frame.setVisible(true);
         }
 
+        searchTextField.select(0, searchTextField.getText().length());
         SwingUtilities.invokeLater(() -> searchTextField.requestFocus());
     }
 

--- a/src/main/java/com/xdavide9/jnotepad/services/MenuBarService.java
+++ b/src/main/java/com/xdavide9/jnotepad/services/MenuBarService.java
@@ -17,10 +17,9 @@ public class MenuBarService {
     private JMenu fileMenu, editMenu, formatMenu, helpMenu;
 
     /** Key used for shortcuts */
-    int shortcutKey;
+    public static int shortcutKey = JNotepad.os == OperatingSystem.MAC ? KeyEvent.META_DOWN_MASK : KeyEvent.CTRL_DOWN_MASK;
 
     public MenuBarService(ActionListener listener) {
-        shortcutKey = JNotepad.os == OperatingSystem.MAC ? KeyEvent.META_DOWN_MASK : KeyEvent.CTRL_DOWN_MASK;
         menuBar = new JMenuBar();
 
         createMenus();


### PR DESCRIPTION
Dark theme wasn't being applied to the title bar on Mac.

Like in Notepad, on CTRL+F, select all text in the Find window's text
field, even if the Find window is already in focus.